### PR TITLE
 Add a way to reuse token and automatically refresh when expired

### DIFF
--- a/src/Auth/Oauth2.php
+++ b/src/Auth/Oauth2.php
@@ -26,6 +26,9 @@ class Oauth2
 
     private $token_expired_at = 0;
 
+    // Opt-in
+    private $auto_refresh_token = false;
+
     public function __construct(array $config = [])
     {
         if (EnvHelper::isStaging() || $config['environment'] === 'staging') {
@@ -77,6 +80,10 @@ class Oauth2
         if (isset($config['token_expired_at'])) {
             $this->token_expired_at = $config['token_expired_at'];
         }
+
+        if (isset($config['auto_refresh_token'])) {
+            $this->auto_refresh_token = $config['auto_refresh_token'];
+        }
     }
 
     public function getContent()
@@ -84,9 +91,12 @@ class Oauth2
         return $this->generateToken()->getContent();
     }
 
-    public function getToken()
+    public function getToken(bool $refreshToken = false)
     {
         $now = (new DateTime('now'))->getTimestamp();
+        if ($refreshToken) {
+            $this->token_expired_at = 0;
+        }
         if ($now >= $this->token_expired_at) {
             $response = $this->generateToken();
             if ($response->getHttpStatus() !== $response::STATUS_2XX) {
@@ -124,5 +134,10 @@ class Oauth2
     public function getOrganizationId()
     {
         return $this->organization_id;
+    }
+
+    public function isTokenAutoRefresh()
+    {
+        return $this->auto_refresh_token;
     }
 }

--- a/src/Auth/Oauth2.php
+++ b/src/Auth/Oauth2.php
@@ -69,6 +69,14 @@ class Oauth2
             $env_clientsecret = EnvHelper::CLIENT_SECRET;
             throw new SSEnvException("Oauth2 - Environment '{$env_clientsecret}' OR Configuration 'client_secret' must be provided.");
         }
+
+        if (isset($config['token'])) {
+            $this->token = $config['token'];
+        }
+
+        if (isset($config['token_expired_at'])) {
+            $this->token_expired_at = $config['token_expired_at'];
+        }
     }
 
     public function getContent()

--- a/src/Request/HttpRequest.php
+++ b/src/Request/HttpRequest.php
@@ -38,7 +38,12 @@ class HttpRequest
         try {
             $response = $guzzle->request($method, $url, $options);
         } catch (ClientException $e) {
-            if ($e->getCode() === 401 && $this->oauth2->isTokenAutoRefresh() && $retry) {
+            if (
+                $e->getCode() === 401 &&
+                $this->oauth2->isTokenAutoRefresh() &&
+                $retry &&
+                json_decode($e->getResponse()->getBody()->getContents())->issue->code === 'invalid-access-token'
+            ) {
                 $this->token = $this->oauth2->getToken(true);
                 return $this->request($method, $url, $payloads, false);
             }


### PR DESCRIPTION
Dikarenakan limitasi SatuSehat dimana /oauth2/v1/access token hanya dapat digunakan 1x per menit. Penggunaan SSClient dimana Objek dibuat dalam beberapa instance berbeda dalam satu waktu waktu akan menyebabkan error.

Otomatisasi refresh token tidak aktif secara default, agar tidak merubah alur yang sampai saat ini berjalan.
Penyimpanan token dapat dilakukan oleh user dengan mendaftarkan listener dengan `addEventListener` pada object OAuth2.

contoh penggunaan: 
```php 
$storedToken = getStoredToken();

$token = $storedToken['token'];
$expiredAt = $storedToken['expiredAt'];
$oauth2 = new Oauth2([
    'environment' => 'staging',
    'client_id' => "xxxxxxxxxxxxxxxxxxxxxxxxx",
    'client_secret' => "xxxxxxxxxxxxxxxxxxxxxxxxx",
    
    // stored token in user's system
    'token' => $token,
    'token_expired_at' => $expiredAt,
    // completely opt-in
    'auto_refresh_token' => true,
]);
$oauth2->addEventListener('token_changed', function ($token, $expiredAt) {
    // user store the new token in case it changed
    storeToken($token, $expiredAt);
})
```

